### PR TITLE
fix: avoid samples cache token

### DIFF
--- a/apps/web/app/api_handler.ts
+++ b/apps/web/app/api_handler.ts
@@ -4,6 +4,7 @@ export async function generate_token(
   room: string,
   peer: string,
 ): Promise<string> {
+  console.log("create token");
   const rawResponse = await fetch(Gateways[0]! + "/token/webrtc", {
     method: "POST",
     headers: {
@@ -12,12 +13,14 @@ export async function generate_token(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ room, peer, ttl: 7200 }),
+    cache: "no-cache",
   });
   const content = await rawResponse.json();
   return content.data.token;
 }
 
 export async function generate_random_token() {
+  console.log("create token");
   const now = new Date().getTime();
   const room = "room-" + now;
   const peer = "peer-" + now;


### PR DESCRIPTION
Currently some sample pages have cache issues, media token is created at build-time cause connect error