### PR TITLE
fix: firefox and restart ice and publish npm

### DIFF
--- a/apps/web/app/react_samples/echo_fast/content.tsx
+++ b/apps/web/app/react_samples/echo_fast/content.tsx
@@ -10,9 +10,9 @@ import {
   RemoteTrack,
   useConsumerStatus,
   Atm0sMediaProvider,
-} from "@atm0s-media-sdk/react-hooks/lib";
+} from "@atm0s-media-sdk/react-hooks";
 
-import { Kind } from "@atm0s-media-sdk/core/lib";
+import { Kind } from "@atm0s-media-sdk/core";
 import { env } from "../../env";
 
 function EchoViewer({ track }: { track: RemoteTrack }) {

--- a/apps/web/app/react_ui_samples/meet/room/page.tsx
+++ b/apps/web/app/react_ui_samples/meet/room/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { Atm0sMediaProvider } from "@atm0s-media-sdk/react-hooks/lib";
-import { Atm0sMediaUIProvider } from "@atm0s-media-sdk/react-ui/lib";
+import { Atm0sMediaProvider } from "@atm0s-media-sdk/react-hooks";
+import { Atm0sMediaUIProvider } from "@atm0s-media-sdk/react-ui";
 import MeetSelection from "./selection";
 import { Suspense } from "react";
 import { useCallback, useMemo, useState } from "react";
 import MeetInRoom from "./room";
 import { useSearchParams } from "next/navigation";
-import { AudioMixerMode, SessionConfig } from "@atm0s-media-sdk/core/lib";
+import { AudioMixerMode, SessionConfig } from "@atm0s-media-sdk/core";
 import { env } from "../../../env";
 
 function MeetContent(): JSX.Element {

--- a/apps/web/app/react_ui_samples/meet/room/room.tsx
+++ b/apps/web/app/react_ui_samples/meet/room/room.tsx
@@ -1,4 +1,4 @@
-import { ControlsPanel, PeersPanel } from "@atm0s-media-sdk/react-ui/lib";
+import { ControlsPanel, PeersPanel } from "@atm0s-media-sdk/react-ui";
 
 interface Props {}
 

--- a/apps/web/app/react_ui_samples/meet/room/selection.tsx
+++ b/apps/web/app/react_ui_samples/meet/room/selection.tsx
@@ -1,5 +1,5 @@
-import { useSession } from "@atm0s-media-sdk/react-hooks/lib";
-import { DevicesSelection } from "@atm0s-media-sdk/react-ui/lib";
+import { useSession } from "@atm0s-media-sdk/react-hooks";
+import { DevicesSelection } from "@atm0s-media-sdk/react-ui";
 import { useCallback } from "react";
 
 interface Props {

--- a/apps/web/app/ts_samples/audio_mixer_auto/content.tsx
+++ b/apps/web/app/ts_samples/audio_mixer_auto/content.tsx
@@ -6,7 +6,7 @@ import {
   AudioMixerMode,
   AudioMixerOutputChanged,
   Session,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { env } from "../../env";
 
 interface Props {

--- a/apps/web/app/ts_samples/audio_mixer_manual/content.tsx
+++ b/apps/web/app/ts_samples/audio_mixer_manual/content.tsx
@@ -8,9 +8,9 @@ import {
   Kind,
   Session,
   SessionEvent,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { env } from "../../env";
-import { RemoteTrack } from "@atm0s-media-sdk/react-hooks/lib";
+import { RemoteTrack } from "@atm0s-media-sdk/react-hooks";
 
 interface Props {
   room: string;

--- a/apps/web/app/ts_samples/echo_fast/content.tsx
+++ b/apps/web/app/ts_samples/echo_fast/content.tsx
@@ -10,7 +10,7 @@ import {
   RoomTrackStopped,
   Session,
   SessionEvent,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { env } from "../../env";
 
 interface Props {

--- a/apps/web/app/ts_samples/echo_lazy/content.tsx
+++ b/apps/web/app/ts_samples/echo_lazy/content.tsx
@@ -10,7 +10,7 @@ import {
   RoomTrackStopped,
   Session,
   SessionEvent,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { env } from "../../env";
 
 interface Props {

--- a/apps/web/app/ts_samples/echo_restart_ice/content.tsx
+++ b/apps/web/app/ts_samples/echo_restart_ice/content.tsx
@@ -10,7 +10,7 @@ import {
   RoomTrackStopped,
   Session,
   SessionEvent,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { env } from "../../env";
 
 interface Props {

--- a/apps/web/app/ts_samples/echo_simulcast/content.tsx
+++ b/apps/web/app/ts_samples/echo_simulcast/content.tsx
@@ -10,7 +10,7 @@ import {
   RoomTrackStopped,
   Session,
   SessionEvent,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { env } from "../../env";
 
 interface Props {

--- a/apps/web/app/ts_samples/multi_track_receivers/content.tsx
+++ b/apps/web/app/ts_samples/multi_track_receivers/content.tsx
@@ -10,7 +10,7 @@ import {
   RoomTrackStopped,
   Session,
   SessionEvent,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { env } from "../../env";
 
 interface Props {

--- a/apps/web/app/ts_samples/switch_sender_track/content.tsx
+++ b/apps/web/app/ts_samples/switch_sender_track/content.tsx
@@ -12,7 +12,7 @@ import {
   SessionEvent,
   TrackReceiverEvent,
   TrackReceiverStatus,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { env } from "../../env";
 
 interface Props {

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,23 +1,30 @@
 {
   "name": "@atm0s-media-sdk/core",
-  "version": "1.0.0-alpha.1",
-  "exports": {
-    "./lib": "./src/lib.ts"
-  },
-  "scripts": {
-    "lint": "eslint . --max-warnings 0"
-  },
+  "version": "1.0.0-alpha.4",
+  "main": "./dist/lib.js",
+  "module": "./dist/lib.mjs",
+  "types": "./dist/lib.d.ts",
+  "files": [
+    "dist/*",
+    "src/*"
+  ],
   "devDependencies": {
-    "@atm0s-media-sdk/eslint-config": "workspace:*",
-    "@atm0s-media-sdk/typescript-config": "workspace:*",
     "@turbo/gen": "^1.12.4",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "eslint": "^8.57.0",
     "ts-proto": "^1.174.0",
-    "typescript": "^5.3.3"
+    "tsup": "^8.1.0",
+    "typescript": "^5.3.3",
+    "@atm0s-media-sdk/typescript-config": "0.0.0",
+    "@atm0s-media-sdk/eslint-config": "0.0.0"
   },
   "dependencies": {
     "protobufjs": "^7.3.0"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "build": "tsup src/lib.ts --format cjs,esm --dts",
+    "dev": "tsup src/lib.ts --format cjs,esm --dts --watch"
   }
 }

--- a/packages/sdk-core/src/data.ts
+++ b/packages/sdk-core/src/data.ts
@@ -33,6 +33,7 @@ export class Datachannel extends EventEmitter {
 
   constructor(private dc: RTCDataChannel) {
     super();
+    dc.binaryType = "arraybuffer";
     dc.onopen = () => {
       console.log("[Datachannel] on open");
       this.waiter.setReady();

--- a/packages/sdk-core/src/receiver.ts
+++ b/packages/sdk-core/src/receiver.ts
@@ -81,6 +81,19 @@ export class TrackReceiver extends EventEmitter {
     this.media_track = this.transceiver.receiver.track;
   }
 
+  /// We need update stream with newest track
+  afterRestartIce() {
+    let old_track = this.media_stream.getTracks()[0]!;
+    let new_track = this.transceiver!.receiver.track;
+    console.log(
+      "[TrackReceiver] restartIce => change track",
+      old_track.id,
+      new_track.id,
+    );
+    this.media_stream.removeTrack(old_track);
+    this.media_stream.addTrack(new_track);
+  }
+
   public async attach(
     source: Receiver_Source,
     config: Receiver_Config = DEFAULT_CFG,

--- a/packages/sdk-react-hooks/package.json
+++ b/packages/sdk-react-hooks/package.json
@@ -1,26 +1,34 @@
 {
   "name": "@atm0s-media-sdk/react-hooks",
-  "version": "1.0.0-alpha.3",
-  "exports": {
-    "./lib": "./src/lib.tsx"
-  },
-  "scripts": {
-    "lint": "eslint . --max-warnings 0",
-    "generate:component": "turbo gen react-component"
-  },
+  "version": "1.0.0-alpha.5",
+  "main": "./dist/lib.js",
+  "module": "./dist/lib.mjs",
+  "types": "./dist/lib.d.ts",
+  "files": [
+    "dist/*",
+    "src/*"
+  ],
   "dependencies": {
-    "@atm0s-media-sdk/core": "workspace:*"
+    "@atm0s-media-sdk/core": "1.0.0-alpha.4"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0"
   },
   "devDependencies": {
-    "@atm0s-media-sdk/eslint-config": "workspace:*",
-    "@atm0s-media-sdk/typescript-config": "workspace:*",
     "@turbo/gen": "^1.12.4",
     "@types/node": "^20.11.24",
     "@types/eslint": "^8.56.5",
     "@types/react": "^18.2.61",
     "@types/react-dom": "^18.2.19",
     "eslint": "^8.57.0",
-    "react": "^18.2.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "tsup": "^8.1.0",
+    "@atm0s-media-sdk/typescript-config": "0.0.0",
+    "@atm0s-media-sdk/eslint-config": "0.0.0"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "build": "tsup src/lib.tsx --format cjs,esm --dts",
+    "dev": "tsup src/lib.tsx --format cjs,esm --dts --watch"
   }
 }

--- a/packages/sdk-react-hooks/src/context.ts
+++ b/packages/sdk-react-hooks/src/context.ts
@@ -14,7 +14,7 @@ import {
   Sender_Config,
   stringToKind,
   JoinInfo,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 
 export enum ContextEvent {
   RoomUpdated = "room.updated",

--- a/packages/sdk-react-hooks/src/hooks/consumer.tsx
+++ b/packages/sdk-react-hooks/src/hooks/consumer.tsx
@@ -8,7 +8,7 @@ import {
   TrackReceiverEvent,
   TrackReceiverStatus,
   TrackReceiverVoiceActivity,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 
 export interface ConsumerConfig {
   priority: number;

--- a/packages/sdk-react-hooks/src/hooks/meta.tsx
+++ b/packages/sdk-react-hooks/src/hooks/meta.tsx
@@ -1,4 +1,4 @@
-import { Kind } from "@atm0s-media-sdk/core/lib";
+import { Kind } from "@atm0s-media-sdk/core";
 import { useContext, useEffect, useState } from "react";
 import { Atm0sMediaContext } from "../provider";
 import { ContextEvent } from "../context";

--- a/packages/sdk-react-hooks/src/hooks/mixer.tsx
+++ b/packages/sdk-react-hooks/src/hooks/mixer.tsx
@@ -3,8 +3,8 @@ import { Atm0sMediaContext } from "../provider";
 import {
   AudioMixerEvent,
   AudioMixerPeerVoiceActivity,
-} from "@atm0s-media-sdk/core/lib";
-export type { AudioMixer } from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
+export type { AudioMixer } from "@atm0s-media-sdk/core";
 
 export function useMixer() {
   const ctx = useContext(Atm0sMediaContext);

--- a/packages/sdk-react-hooks/src/hooks/publisher.tsx
+++ b/packages/sdk-react-hooks/src/hooks/publisher.tsx
@@ -2,7 +2,7 @@ import {
   Kind,
   TrackSenderEvent,
   TrackSenderStatus,
-} from "@atm0s-media-sdk/core/lib";
+} from "@atm0s-media-sdk/core";
 import { Publisher, PublisherConfig } from "../context";
 import { Atm0sMediaContext } from "../provider";
 import { useContext, useEffect, useMemo, useState } from "react";

--- a/packages/sdk-react-hooks/src/hooks/session.tsx
+++ b/packages/sdk-react-hooks/src/hooks/session.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useMemo, useState } from "react";
 import { Atm0sMediaContext } from "../provider";
 import { Context, ContextEvent } from "../context";
-import { JoinInfo } from "@atm0s-media-sdk/core/lib";
+import { JoinInfo } from "@atm0s-media-sdk/core";
 
 const VERSION = "react@0.0.0"; //TODO auto version
 

--- a/packages/sdk-react-hooks/src/provider.tsx
+++ b/packages/sdk-react-hooks/src/provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useEffect, useState } from "react";
-import { SessionConfig } from "@atm0s-media-sdk/core/lib";
+import { SessionConfig } from "@atm0s-media-sdk/core";
 import { Context } from "./context";
 
 export const Atm0sMediaContext = createContext<Context>({} as any);

--- a/packages/sdk-react-ui/package.json
+++ b/packages/sdk-react-ui/package.json
@@ -1,29 +1,38 @@
 {
   "name": "@atm0s-media-sdk/react-ui",
-  "version": "1.0.0-alpha.2",
-  "exports": {
-    "./lib": "./src/lib.tsx"
-  },
-  "scripts": {
-    "lint": "eslint . --max-warnings 0",
-    "generate:component": "turbo gen react-component"
-  },
+  "version": "1.0.0-alpha.4",
+  "main": "./dist/lib.js",
+  "module": "./dist/lib.mjs",
+  "types": "./dist/lib.d.ts",
+  "files": [
+    "dist/*",
+    "src/*"
+  ],
   "dependencies": {
-    "@atm0s-media-sdk/core": "workspace:*",
-    "@atm0s-media-sdk/react-hooks": "workspace:*",
     "@emotion/react": "^11.11.4",
-    "@emotion/styled": "^11.11.5"
+    "@emotion/styled": "^11.11.5",
+    "@atm0s-media-sdk/core": "1.0.0-alpha.4",
+    "@atm0s-media-sdk/react-hooks": "1.0.0-alpha.5"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0"
   },
   "devDependencies": {
-    "@atm0s-media-sdk/eslint-config": "workspace:*",
-    "@atm0s-media-sdk/typescript-config": "workspace:*",
     "@turbo/gen": "^1.12.4",
     "@types/eslint": "^8.56.5",
     "@types/node": "^20.11.24",
     "@types/react": "^18.2.61",
     "@types/react-dom": "^18.2.19",
     "eslint": "^8.57.0",
-    "react": "^18.2.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "tsup": "^8.1.0",
+    "@atm0s-media-sdk/eslint-config": "0.0.0",
+    "@atm0s-media-sdk/typescript-config": "0.0.0"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "build": "tsup src/lib.tsx --format cjs,esm --dts",
+    "dev": "tsup src/lib.tsx --format cjs,esm --dts --watch",
+    "generate:component": "turbo gen react-component"
   }
 }

--- a/packages/sdk-react-ui/src/components/consumers/audio_mixer.tsx
+++ b/packages/sdk-react-ui/src/components/consumers/audio_mixer.tsx
@@ -1,4 +1,4 @@
-import { useMixer } from "@atm0s-media-sdk/react-hooks/lib";
+import { useMixer } from "@atm0s-media-sdk/react-hooks";
 import { useEffect, useRef } from "react";
 
 export function AudioMixerPlayer() {

--- a/packages/sdk-react-ui/src/components/consumers/audio_remote.tsx
+++ b/packages/sdk-react-ui/src/components/consumers/audio_remote.tsx
@@ -2,7 +2,7 @@ import {
   RemoteTrack,
   useConsumer,
   useConsumerVoiceActivity,
-} from "@atm0s-media-sdk/react-hooks/lib";
+} from "@atm0s-media-sdk/react-hooks";
 import { useEffect, useRef } from "react";
 
 interface Props {

--- a/packages/sdk-react-ui/src/components/consumers/peer_remote.tsx
+++ b/packages/sdk-react-ui/src/components/consumers/peer_remote.tsx
@@ -2,7 +2,7 @@ import {
   RemotePeer,
   useRemoteAudioTracks,
   useRemoteVideoTracks,
-} from "@atm0s-media-sdk/react-hooks/lib";
+} from "@atm0s-media-sdk/react-hooks";
 import { AudioRemote } from "./audio_remote";
 import { VideoRemote } from "./video_remote";
 import { AudioMixerSpeaking } from "../uis/audio_mixer_speaking";

--- a/packages/sdk-react-ui/src/components/consumers/video_remote.tsx
+++ b/packages/sdk-react-ui/src/components/consumers/video_remote.tsx
@@ -1,4 +1,4 @@
-import { RemoteTrack, useConsumer } from "@atm0s-media-sdk/react-hooks/lib";
+import { RemoteTrack, useConsumer } from "@atm0s-media-sdk/react-hooks";
 import { useEffect, useRef } from "react";
 
 interface Props {

--- a/packages/sdk-react-ui/src/components/previews/camera.tsx
+++ b/packages/sdk-react-ui/src/components/previews/camera.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
-import { usePublisher } from "@atm0s-media-sdk/react-hooks/lib";
+import { usePublisher } from "@atm0s-media-sdk/react-hooks";
 import { useDeviceStream } from "../../hooks";
 import { Atm0sMediaUIContext } from "../../provider";
-import { BitrateControlMode, Kind } from "@atm0s-media-sdk/core/lib";
+import { BitrateControlMode, Kind } from "@atm0s-media-sdk/core";
 import { CameraIcon, CameraOffIcon } from "../icons/camera";
 
 interface CameraPreviewProps {

--- a/packages/sdk-react-ui/src/components/previews/microphone.tsx
+++ b/packages/sdk-react-ui/src/components/previews/microphone.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { useDeviceStream } from "../../hooks";
 import { Atm0sMediaUIContext } from "../../provider";
-import { usePublisher } from "@atm0s-media-sdk/react-hooks/lib";
-import { Kind } from "@atm0s-media-sdk/core/lib";
+import { usePublisher } from "@atm0s-media-sdk/react-hooks";
+import { Kind } from "@atm0s-media-sdk/core";
 import { MicIcon, MicOffIcon } from "../icons/microphone";
 
 interface MicrophonePreviewProps {

--- a/packages/sdk-react-ui/src/components/uis/audio_mixer_speaking.tsx
+++ b/packages/sdk-react-ui/src/components/uis/audio_mixer_speaking.tsx
@@ -1,4 +1,4 @@
-import { useMixerPeerVoiceActivity } from "@atm0s-media-sdk/react-hooks/lib";
+import { useMixerPeerVoiceActivity } from "@atm0s-media-sdk/react-hooks";
 import { useState, useEffect, ReactNode } from "react";
 
 interface Props {

--- a/packages/sdk-react-ui/src/context.tsx
+++ b/packages/sdk-react-ui/src/context.tsx
@@ -1,4 +1,4 @@
-import { EventEmitter } from "@atm0s-media-sdk/core/lib";
+import { EventEmitter } from "@atm0s-media-sdk/core";
 
 export enum ContextEvent {
   DeviceChanged = "device.changed.",

--- a/packages/sdk-react-ui/src/panels/peers_panel.tsx
+++ b/packages/sdk-react-ui/src/panels/peers_panel.tsx
@@ -1,4 +1,4 @@
-import { useRemotePeers, useRoom } from "@atm0s-media-sdk/react-hooks/lib";
+import { useRemotePeers, useRoom } from "@atm0s-media-sdk/react-hooks";
 import {
   PeerRemoteDirectAudio,
   PeerRemoteMixerAudio,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 3.2.5
       turbo:
         specifier: latest
-        version: 1.13.3
+        version: 2.0.5
 
   apps/docs:
     dependencies:
@@ -156,10 +156,10 @@ importers:
         version: 7.3.0
     devDependencies:
       '@atm0s-media-sdk/eslint-config':
-        specifier: workspace:*
+        specifier: 0.0.0
         version: link:../eslint-config
       '@atm0s-media-sdk/typescript-config':
-        specifier: workspace:*
+        specifier: 0.0.0
         version: link:../typescript-config
       '@turbo/gen':
         specifier: ^1.12.4
@@ -176,6 +176,9 @@ importers:
       ts-proto:
         specifier: ^1.174.0
         version: 1.174.0
+      tsup:
+        specifier: ^8.1.0
+        version: 8.1.0(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -183,14 +186,17 @@ importers:
   packages/sdk-react-hooks:
     dependencies:
       '@atm0s-media-sdk/core':
-        specifier: workspace:*
+        specifier: 1.0.0-alpha.4
         version: link:../sdk-core
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
     devDependencies:
       '@atm0s-media-sdk/eslint-config':
-        specifier: workspace:*
+        specifier: 0.0.0
         version: link:../eslint-config
       '@atm0s-media-sdk/typescript-config':
-        specifier: workspace:*
+        specifier: 0.0.0
         version: link:../typescript-config
       '@turbo/gen':
         specifier: ^1.12.4
@@ -210,9 +216,9 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
+      tsup:
+        specifier: ^8.1.0
+        version: 8.1.0(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -220,10 +226,10 @@ importers:
   packages/sdk-react-ui:
     dependencies:
       '@atm0s-media-sdk/core':
-        specifier: workspace:*
+        specifier: 1.0.0-alpha.4
         version: link:../sdk-core
       '@atm0s-media-sdk/react-hooks':
-        specifier: workspace:*
+        specifier: 1.0.0-alpha.5
         version: link:../sdk-react-hooks
       '@emotion/react':
         specifier: ^11.11.4
@@ -231,12 +237,15 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.5
         version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.2.61)(react@18.2.0)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
     devDependencies:
       '@atm0s-media-sdk/eslint-config':
-        specifier: workspace:*
+        specifier: 0.0.0
         version: link:../eslint-config
       '@atm0s-media-sdk/typescript-config':
-        specifier: workspace:*
+        specifier: 0.0.0
         version: link:../typescript-config
       '@turbo/gen':
         specifier: ^1.12.4
@@ -256,9 +265,9 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
+      tsup:
+        specifier: ^8.1.0
+        version: 8.1.0(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -627,6 +636,213 @@ packages:
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
     dev: false
 
+  /@esbuild/aix-ppc64@0.21.5:
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.21.5:
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.21.5:
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.21.5:
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.21.5:
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.21.5:
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.21.5:
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.21.5:
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.21.5:
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.21.5:
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.21.5:
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.21.5:
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.21.5:
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.21.5:
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.21.5:
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.21.5:
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.21.5:
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.21.5:
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.21.5:
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.21.5:
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.21.5:
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.21.5:
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.21.5:
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@eslint-community/eslint-utils@4.4.0(eslint@8.57.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -915,6 +1131,134 @@ packages:
 
   /@protobufjs/utf8@1.1.0:
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  /@rollup/rollup-android-arm-eabi@4.19.1:
+    resolution: {integrity: sha512-XzqSg714++M+FXhHfXpS1tDnNZNpgxxuGZWlRG/jSj+VEPmZ0yg6jV4E0AL3uyBKxO8mO3xtOsP5mQ+XLfrlww==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.19.1:
+    resolution: {integrity: sha512-thFUbkHteM20BGShD6P08aungq4irbIZKUNbG70LN8RkO7YztcGPiKTTGZS7Kw+x5h8hOXs0i4OaHwFxlpQN6A==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.19.1:
+    resolution: {integrity: sha512-8o6eqeFZzVLia2hKPUZk4jdE3zW7LCcZr+MD18tXkgBBid3lssGVAYuox8x6YHoEPDdDa9ixTaStcmx88lio5Q==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.19.1:
+    resolution: {integrity: sha512-4T42heKsnbjkn7ovYiAdDVRRWZLU9Kmhdt6HafZxFcUdpjlBlxj4wDrt1yFWLk7G4+E+8p2C9tcmSu0KA6auGA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.19.1:
+    resolution: {integrity: sha512-MXg1xp+e5GhZ3Vit1gGEyoC+dyQUBy2JgVQ+3hUrD9wZMkUw/ywgkpK7oZgnB6kPpGrxJ41clkPPnsknuD6M2Q==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.19.1:
+    resolution: {integrity: sha512-DZNLwIY4ftPSRVkJEaxYkq7u2zel7aah57HESuNkUnz+3bZHxwkCUkrfS2IWC1sxK6F2QNIR0Qr/YXw7nkF3Pw==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.19.1:
+    resolution: {integrity: sha512-C7evongnjyxdngSDRRSQv5GvyfISizgtk9RM+z2biV5kY6S/NF/wta7K+DanmktC5DkuaJQgoKGf7KUDmA7RUw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.19.1:
+    resolution: {integrity: sha512-89tFWqxfxLLHkAthAcrTs9etAoBFRduNfWdl2xUs/yLV+7XDrJ5yuXMHptNqf1Zw0UCA3cAutkAiAokYCkaPtw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-powerpc64le-gnu@4.19.1:
+    resolution: {integrity: sha512-PromGeV50sq+YfaisG8W3fd+Cl6mnOOiNv2qKKqKCpiiEke2KiKVyDqG/Mb9GWKbYMHj5a01fq/qlUR28PFhCQ==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.19.1:
+    resolution: {integrity: sha512-/1BmHYh+iz0cNCP0oHCuF8CSiNj0JOGf0jRlSo3L/FAyZyG2rGBuKpkZVH9YF+x58r1jgWxvm1aRg3DHrLDt6A==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.19.1:
+    resolution: {integrity: sha512-0cYP5rGkQWRZKy9/HtsWVStLXzCF3cCBTRI+qRL8Z+wkYlqN7zrSYm6FuY5Kd5ysS5aH0q5lVgb/WbG4jqXN1Q==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.19.1:
+    resolution: {integrity: sha512-XUXeI9eM8rMP8aGvii/aOOiMvTs7xlCosq9xCjcqI9+5hBxtjDpD+7Abm1ZhVIFE1J2h2VIg0t2DX/gjespC2Q==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.19.1:
+    resolution: {integrity: sha512-V7cBw/cKXMfEVhpSvVZhC+iGifD6U1zJ4tbibjjN+Xi3blSXaj/rJynAkCFFQfoG6VZrAiP7uGVzL440Q6Me2Q==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.19.1:
+    resolution: {integrity: sha512-88brja2vldW/76jWATlBqHEoGjJLRnP0WOEKAUbMcXaAZnemNhlAHSyj4jIwMoP2T750LE9lblvD4e2jXleZsA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.19.1:
+    resolution: {integrity: sha512-LdxxcqRVSXi6k6JUrTah1rHuaupoeuiv38du8Mt4r4IPer3kwlTo+RuvfE8KzZ/tL6BhaPlzJ3835i6CxrFIRQ==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.19.1:
+    resolution: {integrity: sha512-2bIrL28PcK3YCqD9anGxDxamxdiJAxA+l7fWIwM5o8UqNy1t3d1NdAweO2XhA0KTDJ5aH1FsuiT5+7VhtHliXg==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@rushstack/eslint-patch@1.5.1:
     resolution: {integrity: sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==}
@@ -1795,12 +2139,27 @@ packages:
       run-applescript: 5.0.0
     dev: true
 
+  /bundle-require@4.2.1(esbuild@0.21.5):
+    resolution: {integrity: sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.17'
+    dependencies:
+      esbuild: 0.21.5
+      load-tsconfig: 0.2.5
+    dev: true
+
   /busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
     dev: false
+
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
 
   /call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
@@ -2357,6 +2716,37 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+    dev: true
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -2429,7 +2819,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-import: 2.29.0(@typescript-eslint/parser@7.1.0)(eslint@8.57.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
@@ -2442,7 +2832,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.17.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2466,6 +2856,7 @@ packages:
       '@typescript-eslint/parser': 6.17.0(eslint@8.57.0)(typescript@5.3.3)
       debug: 3.2.7
       eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.17.0)(eslint-plugin-import@2.29.0)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
@@ -3660,6 +4051,11 @@ packages:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
     dev: true
 
+  /joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+    dev: true
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3761,6 +4157,11 @@ packages:
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  /load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3781,6 +4182,10 @@ packages:
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
+
+  /lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
     dev: true
 
   /lodash@4.17.21:
@@ -4535,6 +4940,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
 
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -4629,6 +5035,11 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  /resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+    dev: true
+
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
     dev: true
@@ -4673,6 +5084,32 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     dependencies:
       glob: 7.2.3
+    dev: true
+
+  /rollup@4.19.1:
+    resolution: {integrity: sha512-K5vziVlg7hTpYfFBI+91zHBEMo6jafYXpkMlqZjg7/zhIG9iHqazBf4xz9AVdjS9BruRn280ROqLI7G3OFRIlw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.19.1
+      '@rollup/rollup-android-arm64': 4.19.1
+      '@rollup/rollup-darwin-arm64': 4.19.1
+      '@rollup/rollup-darwin-x64': 4.19.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.19.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.19.1
+      '@rollup/rollup-linux-arm64-gnu': 4.19.1
+      '@rollup/rollup-linux-arm64-musl': 4.19.1
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.19.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.19.1
+      '@rollup/rollup-linux-s390x-gnu': 4.19.1
+      '@rollup/rollup-linux-x64-gnu': 4.19.1
+      '@rollup/rollup-linux-x64-musl': 4.19.1
+      '@rollup/rollup-win32-arm64-msvc': 4.19.1
+      '@rollup/rollup-win32-ia32-msvc': 4.19.1
+      '@rollup/rollup-win32-x64-msvc': 4.19.1
+      fsevents: 2.3.3
     dev: true
 
   /run-applescript@5.0.0:
@@ -4876,6 +5313,13 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
+    dependencies:
+      whatwg-url: 7.1.0
     dev: true
 
   /spdx-correct@3.2.0:
@@ -5179,6 +5623,17 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+    dependencies:
+      punycode: 2.3.0
+    dev: true
+
+  /tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+    dev: true
+
   /ts-api-utils@1.0.2(typescript@5.3.3):
     resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
     engines: {node: '>=16.13.0'}
@@ -5262,6 +5717,45 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  /tsup@8.1.0(typescript@5.3.3):
+    resolution: {integrity: sha512-UFdfCAXukax+U6KzeTNO2kAARHcWxmKsnvSPXUcfA1D+kU05XDccCrkffCQpFaWDsZfV0jMyTsxU39VfCp6EOg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.2.1(esbuild@0.21.5)
+      cac: 6.7.14
+      chokidar: 3.6.0
+      debug: 4.3.4
+      esbuild: 0.21.5
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.2(postcss@8.4.35)
+      resolve-from: 5.0.0
+      rollup: 4.19.1
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tree-kill: 1.2.2
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
   /tsutils@3.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -5272,64 +5766,64 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /turbo-darwin-64@1.13.3:
-    resolution: {integrity: sha512-glup8Qx1qEFB5jerAnXbS8WrL92OKyMmg5Hnd4PleLljAeYmx+cmmnsmLT7tpaVZIN58EAAwu8wHC6kIIqhbWA==}
+  /turbo-darwin-64@2.0.5:
+    resolution: {integrity: sha512-t/9XpWYIjOhIHUdwiR47SYBGYHkR1zWLxTkTNKZwCSn8BN0cfjPZ1BR6kcwYGxLGBhtl5GBf6A29nq2K7iwAjg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.13.3:
-    resolution: {integrity: sha512-/np2xD+f/+9qY8BVtuOQXRq5f9LehCFxamiQnwdqWm5iZmdjygC5T3uVSYuagVFsZKMvX3ycySwh8dylGTl6lg==}
+  /turbo-darwin-arm64@2.0.5:
+    resolution: {integrity: sha512-//5y4RJvnal8CttOLBwlaBqblcQb1qTlIxLN+I8O3E3rPuvHOupNKB9ZJxYIQ8oWf8ns8Ec8cxQ0GSBLTJIMtA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.13.3:
-    resolution: {integrity: sha512-G+HGrau54iAnbXLfl+N/PynqpDwi/uDzb6iM9hXEDG+yJnSJxaHMShhOkXYJPk9offm9prH33Khx2scXrYVW1g==}
+  /turbo-linux-64@2.0.5:
+    resolution: {integrity: sha512-LDtEDU2Gm8p3lKu//aHXZFRKUCVu68BNF9LQ+HmiCKFpNyK7khpMTxIAAUhDqt+AzlrbxtrxcCpCJaWg1JDjHg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.13.3:
-    resolution: {integrity: sha512-qWwEl5VR02NqRyl68/3pwp3c/olZuSp+vwlwrunuoNTm6JXGLG5pTeme4zoHNnk0qn4cCX7DFrOboArlYxv0wQ==}
+  /turbo-linux-arm64@2.0.5:
+    resolution: {integrity: sha512-84wdrzntErBNxkHcwHxiTZdaginQAxGPnwLTyZj8lpUYI7okPoxy3jKpUeMHN3adm3iDedl/x0mYSIvVVkmOiA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.13.3:
-    resolution: {integrity: sha512-Nudr4bRChfJzBPzEmpVV85VwUYRCGKecwkBFpbp2a4NtrJ3+UP1VZES653ckqCu2FRyRuS0n03v9euMbAvzH+Q==}
+  /turbo-windows-64@2.0.5:
+    resolution: {integrity: sha512-SgaFZ0VW6kHCJogLNuLEleAauAJx2Y48wazZGVRmBpgSUS2AylXesaBMhJaEScYqLz7mIRn6KOgwM8D4wTxI9g==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.13.3:
-    resolution: {integrity: sha512-ouJCgsVLd3icjRLmRvHQDDZnmGzT64GBupM1Y+TjtYn2LVaEBoV6hicFy8x5DUpnqdLy+YpCzRMkWlwhmkX7sQ==}
+  /turbo-windows-arm64@2.0.5:
+    resolution: {integrity: sha512-foUxLOZoru0IRNIxm53fkfM4ubas9P0nTFjIcHtd+E8YHeogt8GqTweNre2e6ri1EHDo71emmuQgpuoFCOXZMg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.13.3:
-    resolution: {integrity: sha512-n17HJv4F4CpsYTvKzUJhLbyewbXjq1oLCi90i5tW1TiWDz16ML1eDG7wi5dHaKxzh5efIM56SITnuVbMq5dk4g==}
+  /turbo@2.0.5:
+    resolution: {integrity: sha512-+6+hcWr4nwuESlKqUc626HMOTd3QT8hUOc9QM45PP1d4nErGkNOgExm4Pcov3in7LTuadMnB0gcd/BuzkEDIPw==}
     hasBin: true
     optionalDependencies:
-      turbo-darwin-64: 1.13.3
-      turbo-darwin-arm64: 1.13.3
-      turbo-linux-64: 1.13.3
-      turbo-linux-arm64: 1.13.3
-      turbo-windows-64: 1.13.3
-      turbo-windows-arm64: 1.13.3
+      turbo-darwin-64: 2.0.5
+      turbo-darwin-arm64: 2.0.5
+      turbo-linux-64: 2.0.5
+      turbo-linux-arm64: 2.0.5
+      turbo-windows-64: 2.0.5
+      turbo-windows-arm64: 2.0.5
     dev: true
 
   /type-check@0.4.0:
@@ -5509,6 +6003,18 @@ packages:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
       defaults: 1.0.4
+    dev: true
+
+  /webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+    dev: true
+
+  /whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
     dev: true
 
   /which-boxed-primitive@1.0.2:

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "env": ["NEXT_PUBLIC_GATEWAYS", "APP_SECRET"],


### PR DESCRIPTION
This PR fix firefox connect error because firefox don't support datachannel id 1000, switched back to 0. This only works after https://github.com/8xFF/atm0s-media-server/pull/402 is merged

Other fix: 
- after restart ice we lost media stream
- npm publish config